### PR TITLE
Add Docker Compose recipe for deployment of Web server and DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,19 @@ $ bower install
 $ grunt build
 $ grunt serve // for development purposes
 ```
+
+## Running site as Docker containers
+
+You can build the Web server and CouchDB Docker containers with Docker Compose.
+Please note, the current Nginx configuration file doesn't have a concept
+of image file storage - it merely proxies image and video file requests
+to the production URLs.
+
+``` bash
+cd <application root directory>
+docker-compose up -d
+docker ps # Note down CouchDB Docker contained ID
+docker exec -it <CouchDB container Docker ID> bash
+$ replicate_couchdb
+$ create_couchdb_reader
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+web:
+  build: ./docker/nginx/
+  ports:
+    - "32771:80"
+  volumes:
+    - /Users/Chris/Development/JavaScript/NataliesGallery/dist:/usr/share/nginx/html:ro
+
+db:
+  build: ./docker/couchdb/
+  environment:
+    COUCHDB_DBNAME: natalie_gallery
+  ports:
+    - "5984:5984"

--- a/docker/couchdb/Dockerfile
+++ b/docker/couchdb/Dockerfile
@@ -1,0 +1,3 @@
+FROM kobretti/couchdb-cors
+
+COPY scripts/* /usr/local/bin/

--- a/docker/couchdb/scripts/create_couchdb_reader
+++ b/docker/couchdb/scripts/create_couchdb_reader
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+COUCHDB_READER="natalie_www"
+COUCHDB_READER_PASSWORD="topSecret"
+
+echo "Creating database reader..."
+
+curl -X PUT http://127.0.0.1:5984/_users/org.couchdb.user:natalie_www \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "'"${COUCHDB_READER}"'", "password": "'"${COUCHDB_READER_PASSWORD}"'", "roles": [], "type": "user"}'
+
+exit 0

--- a/docker/couchdb/scripts/replicate_couchdb
+++ b/docker/couchdb/scripts/replicate_couchdb
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+PRODUCTION_COUCHDB_DB_URL="http://tunia.duckdns.org:5984/natalie_gallery"
+
+echo "Replicating upstream database..."
+
+curl -X POST http://127.0.0.1:5984/_replicate \
+  -H "Content-Type: application/json" \
+  -d '{"source":"'"${PRODUCTION_COUCHDB_DB_URL}"'","target":"'"${COUCHDB_DBNAME}"'"}'
+
+exit 0

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY default.conf /etc/nginx/conf.d/

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       80;
+    server_name  localhost;
+    #server_name tunia.duckdns.local;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+        # Prevent from aggressive caching on OS X/Virtual Box
+        sendfile  off;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # TODO Replace proxy with alias
+    # to paths on Docker host
+    #
+    location /photo/ {
+      proxy_pass http://tunia.duckdns.org/photo/;
+    }
+
+    location /thumbnail/ {
+      proxy_pass http://tunia.duckdns.org/thumbnail/;
+    }
+
+    location /video/ {
+      proxy_pass http://tunia.duckdns.org/video/;
+    }
+
+    #rewrite ^/videos/?$ /videos.html break;
+    location /videos/ {
+      proxy_pass http://tunia.duckdns.org/videos/;
+    }
+}


### PR DESCRIPTION
To deploy the application as Docker containers, change to the
application's root directory and run the following commands:

```
docker-compose up -d
docker ps # Note down CouchDB Docker contained ID
docker exec -it <CouchDB container Docker ID> bash
$ replicate_couchdb
$ create_couchdb_reader
```

Please note, the configuration doesn't currently cover the image
storage.
