### PR TITLE
Modify Docker scripts for easier deployment on Docker host servers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 web:
   build: ./docker/nginx/
   ports:
-    - ":80"
+    - "80:80"
   volumes:
-    - /Users/Chris/Development/JavaScript/NataliesGallery/dist:/usr/share/nginx/html:ro
+    - /srv/WebRoot/tunia.duckdns.org/html:/usr/share/nginx/html:ro
+    - /srv/Shared/Media/Pictures:/srv/Shared/Media/Pictures:ro
+    - /srv/Shared/Media/Video:/srv/Shared/Media/Video:ro
 
 db:
   build: ./docker/couchdb/
@@ -11,3 +13,5 @@ db:
     COUCHDB_DBNAME: natalie_gallery
   ports:
     - "5984:5984"
+  volumes:
+    - /srv/WebRoot/tunia.duckdns.org/couchdb:/usr/local/var/lib/couchdb:rw

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -26,19 +26,22 @@ server {
     # to paths on Docker host
     #
     location /photo/ {
-      proxy_pass http://tunia.duckdns.org/photo/;
+      alias /srv/Shared/Media/Pictures/Natalia/;
+      #proxy_pass http://tunia.duckdns.org/photo/;
     }
 
     location /thumbnail/ {
-      proxy_pass http://tunia.duckdns.org/thumbnail/;
+      alias "/srv/Shared/Media/Pictures/Natalia - low res/";
+      #proxy_pass http://tunia.duckdns.org/thumbnail/;
     }
 
     location /video/ {
-      proxy_pass http://tunia.duckdns.org/video/;
+      alias /srv/Shared/Media/Video/Natalia/;
+      #proxy_pass http://tunia.duckdns.org/video/;
     }
 
-    #rewrite ^/videos/?$ /videos.html break;
-    location /videos/ {
-      proxy_pass http://tunia.duckdns.org/videos/;
-    }
+    rewrite ^/videos/?$ /videos.html break;
+    #location /videos/ {
+    #  proxy_pass http://tunia.duckdns.org/videos/;
+    #}
 }


### PR DESCRIPTION
This includes hard-coded public port 80 and paths to media files.
Also, we no longer proxy to assets on the current live box but
assume they are available on the Docker host system.
